### PR TITLE
Logging improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # 0.1.1-alpha.0
 
+* Log levels may also be given as strings. [#20]
+* Import logging classes directly from `util`: 
+  `import { Logger, LogLevel } from "@forman2/extendit/util"`.
 * Fixed and enhanced API doc of `compileWhenClause` function. [#16]
 * Clarified effect of `extensionDependencies` in `README.md`.
 

--- a/src/framework/util/index.test.ts
+++ b/src/framework/util/index.test.ts
@@ -14,6 +14,8 @@ test("Framework Util API is complete", () => {
     "AssertionError",
     "Disposable",
     "JsonValidationError",
+    "LogLevel",
+    "Logger",
     "assert",
     "assertDefined",
     "capitalize",

--- a/src/framework/util/index.ts
+++ b/src/framework/util/index.ts
@@ -6,6 +6,7 @@
 
 export * as expr from "./expr";
 export * as log from "./log";
+export * from "./log";
 export * from "./assert";
 export * from "./capitalize";
 export * from "./disposable";

--- a/src/framework/util/log/level.test.ts
+++ b/src/framework/util/log/level.test.ts
@@ -10,17 +10,23 @@ import { LogLevel } from "@/util/log";
 test("LogLevel.get()", () => {
   expect(LogLevel.get("ALL")).toBe(LogLevel.ALL);
   expect(LogLevel.get("all")).toBe(LogLevel.ALL);
+  expect(LogLevel.get(LogLevel.ALL)).toBe(LogLevel.ALL);
   expect(LogLevel.get("DEBUG")).toBe(LogLevel.DEBUG);
   expect(LogLevel.get("debug")).toBe(LogLevel.DEBUG);
+  expect(LogLevel.get(LogLevel.DEBUG)).toBe(LogLevel.DEBUG);
   expect(LogLevel.get("INFO")).toBe(LogLevel.INFO);
   expect(LogLevel.get("Info")).toBe(LogLevel.INFO);
+  expect(LogLevel.get(LogLevel.INFO)).toBe(LogLevel.INFO);
   expect(LogLevel.get("WARN")).toBe(LogLevel.WARN);
   expect(LogLevel.get("WARNING")).toBe(LogLevel.WARN);
   expect(LogLevel.get("warning")).toBe(LogLevel.WARN);
+  expect(LogLevel.get(LogLevel.WARN)).toBe(LogLevel.WARN);
   expect(LogLevel.get("ERROR")).toBe(LogLevel.ERROR);
   expect(LogLevel.get("error")).toBe(LogLevel.ERROR);
+  expect(LogLevel.get(LogLevel.ERROR)).toBe(LogLevel.ERROR);
   expect(LogLevel.get("OFF")).toBe(LogLevel.OFF);
   expect(LogLevel.get("Off")).toBe(LogLevel.OFF);
+  expect(LogLevel.get(LogLevel.OFF)).toBe(LogLevel.OFF);
   expect(LogLevel.get("DEFAULT")).toBeInstanceOf(LogLevel);
   expect(LogLevel.get("default")).toBeInstanceOf(LogLevel);
 });
@@ -28,4 +34,5 @@ test("LogLevel.get()", () => {
 test("LogLevel.get() with default", () => {
   expect(LogLevel.get("DEBUG", LogLevel.ALL)).toBe(LogLevel.DEBUG);
   expect(LogLevel.get("DEBOG", LogLevel.ALL)).toBe(LogLevel.ALL);
+  expect(LogLevel.get(LogLevel.ERROR, LogLevel.ALL)).toBe(LogLevel.ERROR);
 });

--- a/src/framework/util/log/level.ts
+++ b/src/framework/util/log/level.ts
@@ -85,25 +85,30 @@ export class LogLevel {
   ) {}
 
   /**
-   * Gets the log level for the given log label.
+   * Gets the log level for the given level label.
    *
-   * @param label The log label, "OFF", "ALL", "DEBUG",
-   *    "INFO", "WARN", or "ERROR".
+   * @param labelOrLevel The level label "OFF", "ALL", "DEBUG",
+   *    "INFO", "WARN", or "ERROR", or a level instance.
    * @returns The log label or `undefined` if no such level exists.
    */
-  static get(label: string): LogLevel | undefined;
+  static get(labelOrLevel: string | LogLevel): LogLevel | undefined;
   /**
    * Gets the log level for the given log label.
    *
-   * @param label The log label, "OFF", "ALL", "DEBUG",
-   *    "INFO", "WARN", or "ERROR".
+   * @param labelOrLevel The level label "OFF", "ALL", "DEBUG",
+   *    "INFO", "WARN", or "ERROR", or a level instance.
    * @param defaultLevel The default level.
+   *    Ignored, if `labelOrLevel` is a valid label or level instance.
    * @returns The log label or the given `defaultLevel`
    *   if no such level exists.
    */
-  static get(label: string, defaultLevel: LogLevel): LogLevel;
-  static get(label: string, defaultLevel?: LogLevel): LogLevel | undefined {
-    const key = label.toUpperCase();
+  static get(labelOrLevel: string | LogLevel, defaultLevel: LogLevel): LogLevel;
+  static get(labelOrLevel: string | LogLevel,
+             defaultLevel?: LogLevel): LogLevel | undefined {
+    if (labelOrLevel instanceof LogLevel) {
+      return labelOrLevel;
+    }
+    const key = labelOrLevel.toUpperCase();
     if (key === "DEFAULT") {
       return LogLevel.get(DEFAULT_LOG_LABEL, LogLevel.DEFAULT);
     }

--- a/src/framework/util/log/logger.test.ts
+++ b/src/framework/util/log/logger.test.ts
@@ -66,10 +66,16 @@ describe("enablement", () => {
     errorOk: boolean
   ) {
     expect(logger.isEnabled()).toBe(ok);
+
     expect(logger.isLevelEnabled(LogLevel.DEBUG)).toBe(debugOk);
     expect(logger.isLevelEnabled(LogLevel.INFO)).toBe(infoOk);
     expect(logger.isLevelEnabled(LogLevel.WARN)).toBe(warnOk);
     expect(logger.isLevelEnabled(LogLevel.ERROR)).toBe(errorOk);
+
+    expect(logger.isLevelEnabled("DEBUG")).toBe(debugOk);
+    expect(logger.isLevelEnabled("INFO")).toBe(infoOk);
+    expect(logger.isLevelEnabled("WARN")).toBe(warnOk);
+    expect(logger.isLevelEnabled("ERROR")).toBe(errorOk);
   }
 
   test("global ALL and logger ALL", () => {
@@ -91,22 +97,41 @@ describe("enablement", () => {
     assertLoggerEnablement(logger, false, false, false, false, false);
   });
 
-  test("global WARN and logger ALL", () => {
-    Logger.setGlobalLevel(LogLevel.WARN);
+  test("global ERROR and logger ALL", () => {
+    Logger.setGlobalLevel(LogLevel.ERROR);
 
     const logger = new Logger("test", LogLevel.ALL);
-    assertLoggerEnablement(logger, true, false, false, true, true);
+    assertLoggerEnablement(logger, true, false, false, false, true);
 
     logger.setLevel(LogLevel.INFO);
-    assertLoggerEnablement(logger, true, false, false, true, true);
+    assertLoggerEnablement(logger, true, false, false, false, true);
 
     logger.setLevel(LogLevel.WARN);
-    assertLoggerEnablement(logger, true, false, false, true, true);
+    assertLoggerEnablement(logger, true, false, false, false, true);
 
     logger.setLevel(LogLevel.ERROR);
     assertLoggerEnablement(logger, true, false, false, false, true);
 
     logger.setLevel(LogLevel.OFF);
+    assertLoggerEnablement(logger, false, false, false, false, false);
+  });
+
+  test("global WARN and logger INFO using labels", () => {
+    Logger.setGlobalLevel("WARN");
+
+    const logger = new Logger("test", LogLevel.ALL);
+    assertLoggerEnablement(logger, true, false, false, true, true);
+
+    logger.setLevel("INFO");
+    assertLoggerEnablement(logger, true, false, false, true, true);
+
+    logger.setLevel("WARN");
+    assertLoggerEnablement(logger, true, false, false, true, true);
+
+    logger.setLevel("ERROR");
+    assertLoggerEnablement(logger, true, false, false, false, true);
+
+    logger.setLevel("OFF");
     assertLoggerEnablement(logger, false, false, false, false, false);
   });
 });
@@ -135,6 +160,13 @@ describe("logging methods", () => {
   test("using console with logger level", () => {
     const logger = new Logger("test", LogLevel.ALL);
     logStuff(logger);
+  });
+
+  test("log functions (smoke tests)", () => {
+    Logger.setGlobalLevel(new LogLevel("WEIRD", 0));
+    logStuff(new Logger("test"));
+    logStuff(new Logger("test", LogLevel.ALL));
+    logStuff(new Logger("test", new LogLevel("WEIRD", 0), undefined));
   });
 
   test("generated records", () => {

--- a/src/framework/util/log/logger.ts
+++ b/src/framework/util/log/logger.ts
@@ -40,12 +40,12 @@ export class Logger {
 
   /**
    * Sets the global log level applicable to all loggers.
-   * @param level - The new global log level
+   * @param level - The new global log level or level label
    * @returns The previous global level
    */
-  static setGlobalLevel(level: LogLevel): LogLevel {
+  static setGlobalLevel(level: LogLevel | string): LogLevel {
     const prevLevel = Logger.globalLevel;
-    Logger.globalLevel = level;
+    Logger.globalLevel = LogLevel.get(level, prevLevel);
     return prevLevel;
   }
 
@@ -77,10 +77,14 @@ export class Logger {
 
   /**
    * Sets the logger's level.
-   * @param level - the new level or undefined
+   * @param level - the new level or level label or `null`, or `undefined`.
    */
-  setLevel(level: LogLevel | undefined | null) {
-    this.level = !level ? undefined : level;
+  setLevel(level: LogLevel | string | undefined | null) {
+    if (!level) {
+      this.level = undefined;
+    } else {
+      this.level = LogLevel.get(level);
+    }
   }
 
   /**
@@ -92,11 +96,15 @@ export class Logger {
 
   /**
    * Checks whether this logger is enabled for the given the log level.
-   * @param level - the log level
+   * @param levelOrLabel - The log level or level label.
    */
-  isLevelEnabled(level: LogLevel): boolean {
+  isLevelEnabled(levelOrLabel: LogLevel | string): boolean {
+    if (!this.isEnabled()) {
+      return false;
+    }
+    const level = LogLevel.get(levelOrLabel);
     return (
-      this.isEnabled() &&
+      !!level &&
       level.value >= Logger.getGlobalLevel().value &&
       level.value >= this.getLevel().value
     );


### PR DESCRIPTION
* Log levels may also be given as strings. [#20]
* Import logging classes directly from `util`: 
  `import { Logger, LogLevel } from "@forman2/extendit/util"`.

Closes #20