### PR TITLE
Changed type parameter name from `Data` to `Value`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # 0.1.1-alpha.0
 
+* Changed type parameter name from `Data` to `Value`. [#24]
+  Corresponding to this change, also changed property name `data`
+  into `value` in type `CodeContribution<Value>`. 
 * Fixed the `registerCodeContribution` function to be fully reactive. [#23]
 * Log levels may also be given as strings. [#20]
 * Import logging classes directly from `util`: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forman2/extendit",
-  "version": "0.1.1-alpha",
+  "version": "0.2.0-alpha",
   "type": "module",
   "displayName": "ExtendIt.js",
   "description": "A framework supporting development of extensible and scalable JavaScript applications",

--- a/src/framework/contrib/tool-views.ts
+++ b/src/framework/contrib/tool-views.ts
@@ -121,7 +121,7 @@ export function useToolViewComponent(
     toolViewsPoint.id,
     viewId
   );
-  return (!codeContribution?.loading && codeContribution?.data) || undefined;
+  return (!codeContribution?.loading && codeContribution?.value) || undefined;
 }
 
 export interface ToolViewComponentProps {

--- a/src/framework/core/code-contrib/get.ts
+++ b/src/framework/core/code-contrib/get.ts
@@ -12,14 +12,15 @@ import { frameworkStore } from "@/core/store";
  * an empty map is returned.
  *
  * @category Extension Contribution API
+ * @typeParam Value - Expected type of the code contribution value
  * @param contribPointId - The code contribution point identifier.
  * @returns A read-only map of code contributions
  *  or `undefined` if it does not exist.
  */
-export function getCodeContributions<Data>(
+export function getCodeContributions<Value>(
   contribPointId: string
-): ReadonlyMap<string, Data> | undefined {
+): ReadonlyMap<string, Value> | undefined {
   return frameworkStore.getState().codeContributions[
     contribPointId
-  ] as ReadonlyMap<string, Data>;
+  ] as ReadonlyMap<string, Value>;
 }

--- a/src/framework/core/code-contrib/load.ts
+++ b/src/framework/core/code-contrib/load.ts
@@ -15,16 +15,17 @@ import { getContributionPoint } from "@/core/contrib-point/get";
  * given `contribPoint.activationEvent`, if any.
  *
  * @category Extension Contribution API
+ * @typeParam Value - Type of the loaded code contribution value
  * @param contribPointId - The contribution point identifier.
  * @param contribId - The code contribution identifier.
  * @returns A promise that resolves to the code contribution data.
  * @throws Error - If the contribution point is unknown
  *  or if the contribution identifier is not registered
  */
-export async function loadCodeContribution<Data>(
+export async function loadCodeContribution<Value>(
   contribPointId: string,
   contribId: string
-): Promise<Data> {
+): Promise<Value> {
   let contribDataMap = getStoreRecord("codeContributions", contribPointId);
   if (!contribDataMap || !contribDataMap.has(contribId)) {
     const contribPoint = getContributionPoint(contribPointId, true);
@@ -39,5 +40,5 @@ export async function loadCodeContribution<Data>(
       `Unregistered code contribution '${contribPointId}/${contribId}'.`
     );
   }
-  return Promise.resolve(contribDataMap.get(contribId) as Data);
+  return Promise.resolve(contribDataMap.get(contribId) as Value);
 }

--- a/src/framework/core/code-contrib/register.ts
+++ b/src/framework/core/code-contrib/register.ts
@@ -8,32 +8,33 @@ import { getStoreRecord, setStoreRecord } from "@/core/store";
 import { Disposable } from "@/util/disposable";
 
 /**
- * Registers the given code contribution.
+ * Registers the given code contribution value.
  * Note, it is not required that given `contribPointId`
  * is a registered contribution point. That is, a code contribution
- * can be registered without any JSON (meta)data from manifest.
+ * can be registered without any corresponding JSON entries from manifest.
  *
  * @category Extension Contribution API
+ * @typeParam Value - Type of the code contribution value
  * @param contribPointId - The contribution point identifier.
  * @param contribId - The contribution identifier.
- * @param contribData - The code contribution.
+ * @param contribValue - The code contribution value.
  * @returns Disposable A disposable that unregisters the code contribution.
  */
-export function registerCodeContribution<Data>(
+export function registerCodeContribution<Value>(
   contribPointId: string,
   contribId: string,
-  contribData: Data
+  contribValue: Value
 ): Disposable {
   let contribDataMap = getStoreRecord("codeContributions", contribPointId);
   if (contribDataMap) {
-    if (Object.is(contribDataMap.get(contribId), contribData)) {
+    if (Object.is(contribDataMap.get(contribId), contribValue)) {
       return new Disposable(() => {});
     }
     contribDataMap = new Map(contribDataMap.entries());
   } else {
     contribDataMap = new Map();
   }
-  contribDataMap.set(contribId, contribData);
+  contribDataMap.set(contribId, contribValue);
   setStoreRecord("codeContributions", contribPointId, contribDataMap);
   return new Disposable(() => {
     const contribDataMap = getStoreRecord("codeContributions", contribPointId);

--- a/src/framework/core/types.ts
+++ b/src/framework/core/types.ts
@@ -273,20 +273,20 @@ export interface CodeContributionInfo<TS = unknown> {
  * or that is already loaded.
  *
  * @category Extension Contribution API
- * @typeParam Data - Type of the loaded code contribution data
+ * @typeParam Value - Type of the loaded code contribution value
  */
-export interface CodeContribution<Data = unknown> {
+export interface CodeContribution<Value = unknown> {
   /**
    * While `true` the code contribution data is being loaded.
-   * Then {@link data} and {@link error} are undefined.
+   * Then {@link value} and {@link error} are undefined.
    * If `false`, loading code contribution data either succeeded or failed.
    */
   loading: boolean;
   /**
-   * The loaded code contribution data or `undefined`
+   * The loaded code contribution value or `undefined`
    * while {@link loading} is `true` or if an {@link error} occurred.
    */
-  data?: Data;
+  value?: Value;
   /**
    * If defined, loading of code contribution data failed.
    */

--- a/src/framework/react/hooks.ts
+++ b/src/framework/react/hooks.ts
@@ -33,7 +33,8 @@ import { getExtensionsMemo } from "@/core/extension/get";
 // 2. Return result of get<Name>Memo(deps + args)
 
 /**
- * A React hook that gets data from the framework's store.
+ * A React hook that gets data from the framework's store
+ * using the given `selector` function.
  *
  * @internal
  * @category React Hooks
@@ -118,12 +119,13 @@ export function useContributionPoints(): ContributionPoint[] {
  * `undefined`. TODO: Find out how we can we avoid this behaviour.
  *
  * @category React Hooks
+ * @typeParam Value - Type of the loaded code contribution value.
  * @returns The current state of the code contribution or `undefined`.
  */
-export function useLoadCodeContribution<Data = unknown>(
+export function useLoadCodeContribution<Value = unknown>(
   contribPointId: string,
   contribId: string
-): CodeContribution<Data> | undefined {
+): CodeContribution<Value> | undefined {
   // TODO: Check, if we'd need to put this state into our frameworkStore.
   //   Otherwise, the state is only available until unmount of the
   //   component that owns this state.
@@ -156,7 +158,7 @@ export function useLoadCodeContribution<Data = unknown>(
         }));
       });
   }, [contribPointId, contribId, dataId, dataStates]);
-  return dataStates[dataId] as CodeContribution<Data> | undefined;
+  return dataStates[dataId] as CodeContribution<Value> | undefined;
 }
 
 /**
@@ -165,15 +167,16 @@ export function useLoadCodeContribution<Data = unknown>(
  * an empty map is returned.
  *
  * @category React Hooks
+ * @typeParam Value - Type of the code contribution values in the map.
  * @param contribPointId - The code contribution point identifier.
  * @returns A read-only map of code contributions.
  */
-export function useCodeContributions<Data = unknown>(
+export function useCodeContributions<Value = unknown>(
   contribPointId: string
-): ReadonlyMap<string, Data> {
+): ReadonlyMap<string, Value> {
   const codeContribMap = useStore((s) => s.codeContributions[contribPointId]);
   return useMemo(
     () => codeContribMap || new Map(),
     [codeContribMap]
-  ) as ReadonlyMap<string, Data>;
+  ) as ReadonlyMap<string, Value>;
 }


### PR DESCRIPTION
Changed type parameter name from `Data` to `Value`. 
Corresponding to this change, also changed property name `data` into `value` in type `CodeContribution<Value>`. 

Closes #24