### PR TITLE
Address eslint warnings

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,10 +38,6 @@ module.exports = {
     "react-refresh/only-export-components": [
       "warn",
       { allowConstantExport: true },
-    ],
-    "@typescript-eslint/restrict-template-expressions": [
-      "warn",
-      {},
-    ],
+    ]
   },
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run build
+    - run: npm run lint
     - run: npm run coverage
     - if: ${{ matrix.node-version == '18.x' }}
       name: Upload coverage reports to Codecov

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,16 +1,26 @@
 # 0.2.0 (in development)
 
-* Enhanced API docs for React Hooks. [#27]
+## Breaking changes
+
 * Changed type parameter name from `Data` to `Value`. [#24]
   Corresponding to this change, also changed property name `data`
-  into `value` in type `CodeContribution<Value>`. 
+  into `value` in type `CodeContribution<Value>`.
+
+## Fixes
+
 * Fixed the `registerCodeContribution` function to be fully reactive. [#23]
-* Log levels may also be given as strings. [#20]
-* Import logging classes directly from `util`: 
-  `import { Logger, LogLevel } from "@forman2/extendit/util"`.
 * Fixed and enhanced API doc of `compileWhenClause` function. [#16]
+
+## Other enhancements
+
+* Enhanced API docs for React Hooks. [#27]
+* Log levels may also be given as strings. [#20]
+* Import logging classes directly from `util`:
+  `import { Logger, LogLevel } from "@forman2/extendit/util"`.
 * Clarified effect of `extensionDependencies` in `README.md`.
-* Addressed all `eslint` warnings in code and CI now also runs `npm run lint`.
+* Addressed all `eslint` warnings in code and GitHub CI now also
+  runs `npm run lint`. [#28]
+
 
 # 0.1.0 (from 18.11.2023)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
   `import { Logger, LogLevel } from "@forman2/extendit/util"`.
 * Fixed and enhanced API doc of `compileWhenClause` function. [#16]
 * Clarified effect of `extensionDependencies` in `README.md`.
+* Addressed all `eslint` warnings in code and CI now also runs `npm run lint`.
 
 # 0.1.0 (from 18.11.2023)
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "preview": "vite preview",
     "test": "vitest",
     "coverage": "vitest run --coverage",

--- a/src/framework/core/extension/activate.test.ts
+++ b/src/framework/core/extension/activate.test.ts
@@ -98,7 +98,7 @@ test("activateExtension fails for missing main.js file", async () => {
   expect(extension.status).toEqual("rejected");
   expect(Array.isArray(extension.reasons)).toBe(true);
   expect(extension.reasons).toHaveLength(1);
-  expect(`${extension.reasons![0]}`).toMatch("Failed to load url main.js");
+  expect(extension.reasons![0] + "").toMatch("Failed to load url main.js");
   disposable.dispose();
 });
 
@@ -112,7 +112,7 @@ test("activateExtension fails on activation", async () => {
   expect(Array.isArray(extension.reasons)).toBe(true);
   expect(extension.reasons).toHaveLength(1);
   expect(extension.reasons![0]).toBeInstanceOf(Error);
-  expect(`${extension.reasons![0]}`).toMatch(
+  expect(extension.reasons![0] + "").toMatch(
     "Failed by intention: pippo.will-fail-on-activation"
   );
   disposable.dispose();
@@ -133,10 +133,10 @@ test("activateExtension fails for failing dependency", async () => {
   expect(extension.status).toEqual("rejected");
   expect(Array.isArray(extension.reasons)).toBe(true);
   expect(extension.reasons).toHaveLength(2);
-  expect(`${extension.reasons![0]}`).toMatch(
+  expect(extension.reasons![0] + "").toMatch(
     "Extension 'pippo.requires-failing' rejected because dependencies could not be resolved."
   );
-  expect(`${extension.reasons![1]}`).toMatch(
+  expect(extension.reasons![1] + "").toMatch(
     "Failed by intention: pippo.will-fail-on-activation"
   );
   disposable1.dispose();

--- a/src/framework/core/extension/deactivate.test.ts
+++ b/src/framework/core/extension/deactivate.test.ts
@@ -57,7 +57,7 @@ test("deactivateExtension with failing deactivate()", async () => {
   expect(Array.isArray(extension.reasons)).toBe(true);
   expect(extension.reasons).toHaveLength(1);
   expect(extension.reasons![0]).toBeInstanceOf(Error);
-  expect(`${extension.reasons![0]}`).toMatch(
+  expect(extension.reasons![0] + "").toMatch(
     "Failed by intention: pippo.will-fail-on-deactivation"
   );
   disposable.dispose();

--- a/src/framework/core/extension/set.ts
+++ b/src/framework/core/extension/set.ts
@@ -69,8 +69,7 @@ export function setExtensionStatus(
         ? r
         : typeof r === "string"
         ? new Error(r)
-        : // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          new Error(`${r})`)
+        : new Error(r + "")
     );
     nextExtension = {
       ...nextExtension,

--- a/src/framework/util/assert.ts
+++ b/src/framework/util/assert.ts
@@ -51,7 +51,7 @@ export function assertDefined<T>(
 ): asserts value is NonNullable<T> {
   if (value === undefined || value === null) {
     throw AssertionError.fromMessage(
-      message ?? `Expected 'value' to be defined, but received ${value}`
+      message ?? `Expected 'value' to be defined, but received ${value + ""}`
     );
   }
 }

--- a/src/framework/util/expr/node.ts
+++ b/src/framework/util/expr/node.ts
@@ -47,7 +47,6 @@ export class Literal<T> extends Node<T> {
   }
 
   toString(): string {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     return `${typeof this.value}(${this.value})`;
   }
 }
@@ -236,7 +235,7 @@ export class Assign extends Node {
       } else {
         throw new Error(
           'An array index must have type "number" or "string", ' +
-            `was type "${typeof indexValue}": ${indexValue}`
+            `was type "${typeof indexValue}": ${indexValue + ""}`
         );
       }
     }

--- a/src/framework/util/expr/ops.test.ts
+++ b/src/framework/util/expr/ops.test.ts
@@ -11,7 +11,7 @@ import type { BinaryOp, UnaryOp } from "./ops";
 describe("unary ops", () => {
   function assertUnaryOps<T>(x: unknown, expected: [UnaryOp, T][]) {
     expected.forEach(([op, result]) => {
-      expect(op(x), `${op.name}(${x})`).toEqual(result);
+      expect(op(x), `${op.name}(${String(x)})`).toEqual(result);
     });
   }
 
@@ -35,7 +35,9 @@ describe("binary ops", () => {
     expected: [BinaryOp, T][]
   ) {
     expected.forEach(([op, result]) => {
-      expect(op(x, y), `${op.name}(${x}, ${y})`).toEqual(result);
+      expect(op(x, y), `${op.name}(${String(x)}, ${String(y)})`).toEqual(
+        result
+      );
     });
   }
 

--- a/src/framework/util/expr/parser.ts
+++ b/src/framework/util/expr/parser.ts
@@ -87,7 +87,6 @@ export class Parser {
       } else {
         throw this.error(
           `Missing ":" after "?" of conditional` +
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             ` near "${this.token().value}".`
         );
       }

--- a/src/framework/util/expr/scanner.ts
+++ b/src/framework/util/expr/scanner.ts
@@ -17,7 +17,7 @@ export type TokenType =
 
 export interface Token {
   type: TokenType;
-  value: unknown;
+  value: string | number;
 }
 
 // End-of-token-stream marker

--- a/src/framework/util/key.ts
+++ b/src/framework/util/key.ts
@@ -11,11 +11,13 @@
 export function keyFromValue(value: unknown): string {
   return typeof value === "string"
     ? value
+    : value === null
+    ? "null"
     : Array.isArray(value)
     ? keyFromArray(value)
-    : typeof value === "object" && value !== null
+    : typeof value === "object"
     ? keyFromObject(value)
-    : `${value}`;
+    : value + "";
 }
 
 /**

--- a/src/framework/util/log/logger.ts
+++ b/src/framework/util/log/logger.ts
@@ -22,7 +22,7 @@ export class Logger {
    * @returns A global logger instance.
    */
   static getLogger(name?: string): Logger {
-    let key = name ?? "";
+    const key = name ?? "";
     let logger = Logger.instances.get(key);
     if (!logger) {
       logger = new Logger(key);


### PR DESCRIPTION
Addressed all `eslint` warnings in code and GitHub CI now also runs `npm run lint`. 


Closes #28